### PR TITLE
Return 422 on Irrelevant Requests

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      
+
 env:
   DOCKER_HUB_SPACE: "lunarapi"
 
@@ -14,13 +14,7 @@ jobs:
     strategy:
       matrix:
         app:
-          [
-            {
-              name: "webrisk-server",
-              context: ".",
-              dockerfile: "./Dockerfile",
-            },
-          ]
+          [{ name: "webrisk-server", context: ".", dockerfile: "./Dockerfile" }]
 
     outputs:
       version: ${{ steps.meta.outputs.version }}
@@ -76,17 +70,3 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-## TODO: uncomment after service is added manually to gitops
-  # gitops_cd:
-  #   needs: docker
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-
-  #     - name: Trigger Deploy Workflow
-  #       run: |
-  #         gh workflow run gitops-cd.yml -f service=webrisk-server -f environment=staging-lunar-gcp -f version=${{ needs.docker.outputs.version }}
-  #       env:
-  #         GH_TOKEN: ${{ secrets.GIT_TOKEN }}


### PR DESCRIPTION
This PR will return 422 on irrelevant requests, currently detectable by the word "irrelevant" in the error (ideally, validation would have occurred on the route level, but this is a bigger change)